### PR TITLE
Handle inconsistent TabularInput (rlworkgroup#45)

### DIFF
--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -1,5 +1,6 @@
 """A `dowel.logger.LogOutput` for CSV files."""
 import csv
+import fileinput
 import warnings
 
 from dowel import TabularInput
@@ -11,9 +12,29 @@ class CsvOutput(FileOutput):
     """CSV file output for logger.
 
     :param file_name: The file this output should log to.
+    :param implementation (str): Specify which implementation to use for
+        handling inconsistent TabularInput keys. (Default it None.)
+
+        For the 'copy' implementation, the complete header is written when
+        closing the output. Data rows are copied and rewritten as if they were
+        written with the complete header / fieldnames (i.e. missing keys will
+        have '' as the values).
+
+        For the 'fixed_header_length' implementation, only the header is
+        rewritten when there is a new key. This may be more efficient than
+        'copy' for large amount of data, but it requires allocating enough
+        characters for the header line, due to the nature of file IO. The
+        trailing whitespace for the last fieldname needs to be stripped when
+        using csv.DictReader().
+    :param header_length (int): The header length (number of characters) for
+        the 'fixed_header_length' implementation. (Default is 140.)
+        Header shorter than the header_length will be padded with whitespace.
+        Header longer than the header_length will be truncated.
     """
 
-    def __init__(self, file_name):
+    def __init__(self, file_name, implementation=None, header_length=140):
+        self._inconsistency_handling = implementation
+        self._header_length = header_length
         super().__init__(file_name)
         self._writer = None
         self._fieldnames = None
@@ -35,19 +56,47 @@ class CsvOutput(FileOutput):
 
             if not self._writer:
                 self._fieldnames = set(to_csv.keys())
-                self._writer = csv.DictWriter(
-                    self._log_file,
-                    fieldnames=self._fieldnames,
-                    extrasaction='ignore')
-                self._writer.writeheader()
+                fieldnames_ordered = list(to_csv.keys())
+                self._writer = csv.DictWriter(self._log_file,
+                                              fieldnames=fieldnames_ordered,
+                                              extrasaction='ignore')
+                if self._inconsistency_handling == 'fixed_header_length':
+                    # Manually write the header with padding
+                    header = ','.join(fieldnames_ordered)
+                    header_padded = '{:<{}}'.format(header,
+                                                    self._header_length)
+                    header_trucated = header_padded[:self._header_length] \
+                        + '\r\n'  # Default line ending for csv writer
+                    self._log_file.write(header_trucated)
+                else:
+                    self._writer.writeheader()
 
             if to_csv.keys() != self._fieldnames:
+                # May need to change the content of the warning
+                # to reflect new handling of inconsistent TabularInput
                 self._warn('Inconsistent TabularInput keys detected. '
                            'CsvOutput keys: {}. '
                            'TabularInput keys: {}. '
                            'Did you change key sets after your first '
                            'logger.log(TabularInput)?'.format(
                                set(self._fieldnames), set(to_csv.keys())))
+                if self._inconsistency_handling:
+                    # Check if data contains new fieldnames
+                    fieldnames_new = to_csv.keys() - self._fieldnames
+                    if fieldnames_new:
+                        # Update the fieldnames
+                        self._fieldnames.update(fieldnames_new)
+                        self._writer.fieldnames.extend(list(fieldnames_new))
+                        # Rewrite the header
+                        if self._inconsistency_handling == \
+                                'fixed_header_length':
+                            self._log_file.seek(0)
+                            header = ','.join(self._writer.fieldnames)
+                            header_length = min(len(header),
+                                                self._header_length)
+                            header_trucated = header[:header_length]
+                            self._log_file.write(header_trucated)
+                            self._log_file.seek(0, 2)
 
             self._writer.writerow(to_csv)
 
@@ -56,6 +105,30 @@ class CsvOutput(FileOutput):
         else:
             raise ValueError('Unacceptable type.')
 
+    def close(self):
+        """Close any files used by the output.
+
+        This method will also carry out handling of inconsistent TabularInput
+        keys with the 'copy' implementation, if specified for the output.
+        """
+        super().close()
+        if self._inconsistency_handling == 'copy':
+            # Rewrite the file with a complete header
+            # This involves copying the content of the file
+            with fileinput.input(files=self._log_file.name, inplace=True) as f:
+                fieldnames = self._writer.fieldnames
+                reader = csv.DictReader(f, fieldnames=fieldnames, restval='')
+                header = ','.join(fieldnames)
+
+                for row in reader:
+                    if f.isfirstline():
+                        print(header)
+                    else:
+                        # Emulate csv.DictWriter with restval=''
+                        values = [row.get(key, '') for key in fieldnames]
+                        row_new = ','.join(values)
+                        print(row_new)
+
     def _warn(self, msg):
         """Warns the user using warnings.warn.
 
@@ -63,8 +136,9 @@ class CsvOutput(FileOutput):
         is the one printed.
         """
         if not self._disable_warnings and msg not in self._warned_once:
-            warnings.warn(
-                colorize(msg, 'yellow'), CsvOutputWarning, stacklevel=3)
+            warnings.warn(colorize(msg, 'yellow'),
+                          CsvOutputWarning,
+                          stacklevel=3)
         self._warned_once.add(msg)
         return msg
 

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -54,6 +54,174 @@ class TestCsvOutput:
         correct = [
             {'foo': str(foo)},
             {'foo': str(foo * 2)},
+            {'foo': str(foo * 2)},
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    def test_record_stale(self):
+        foo = 1
+        bar = 10
+        self.tabular.record('foo', foo)
+        self.tabular.record('bar', bar)
+        self.csv_output.record(self.tabular)
+        self.tabular.record('foo', foo * 2)
+        self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        # expected = [
+        #     {'foo': str(foo), 'bar': str(bar)},
+        #     {'foo': str(foo * 2), 'bar': ''},
+        # ]  # yapf: disable
+
+        stale = [
+            {'foo': str(foo), 'bar': str(bar)},
+            {'foo': str(foo * 2), 'bar': str(bar)},
+        ]  # yapf: disable
+        self.assert_csv_matches(stale)
+
+    def test_record_nonprimitive(self):
+        foo = 1
+        bar = 10
+        self.tabular.record('foo', foo)
+        self.tabular.record('bar', bar)
+        self.csv_output.record(self.tabular)
+        self.tabular.record('foo', foo * 2)
+        self.tabular.record('bar', None)
+
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        correct = [
+            {'foo': str(foo), 'bar': str(bar)},
+            {'foo': str(foo * 2), 'bar': ''},
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    def test_record_inconsistency_handling_copy(self):
+        self.csv_output._inconsistency_handling = 'copy'
+
+        a = 1
+        b = 10
+        c = 100
+        d = 1000
+        x = -1
+
+        self.tabular.record('a', a)
+        self.tabular.record('b', b)
+        self.tabular.record('c', c)
+        self.csv_output.record(self.tabular)
+
+        self.tabular.record('a', a * 2)
+        self.tabular.record('b', None)
+        self.tabular.record('c', c * 2)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.tabular.record('a', None)
+        self.tabular.record('b', None)
+        self.tabular.record('c', None)
+        self.tabular.record('x', x * 3)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.tabular.record('b', b * 4)
+        self.tabular.record('x', x * 4)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.tabular.record('b', b * 5)
+        self.tabular.record('x', x * 5)
+        self.tabular.record('d', d * 5)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        self.csv_output.close()
+
+        correct = [
+            {'a': str(a), 'b': str(b), 'c': str(c), 'x': '', 'd': ''},
+            {'a': str(a * 2), 'b': '', 'c': str(c * 2), 'x': '', 'd': ''},
+            {'a': '', 'b': '', 'c': '', 'x': str(x * 3), 'd': ''},
+            {'a': '', 'b': str(b * 4), 'c': '', 'x': str(x * 4), 'd': ''},
+            {'a': '', 'b': str(b*5), 'c': '', 'x': str(x*5), 'd': str(d*5)},
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    def test_record_inconsistency_handling_fixed_header_length(self):
+        self.csv_output._inconsistency_handling = 'fixed_header_length'
+
+        a = 1
+        b = 10
+        c = 100
+        d = 1000
+        x = -1
+
+        self.tabular.record('a', a)
+        self.tabular.record('b', b)
+        self.tabular.record('c', c)
+        self.csv_output.record(self.tabular)
+
+        self.tabular.record('a', a * 2)
+        self.tabular.record('b', None)
+        self.tabular.record('c', c * 2)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.tabular.record('a', None)
+        self.tabular.record('b', None)
+        self.tabular.record('c', None)
+        self.tabular.record('x', x * 3)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.tabular.record('b', b * 4)
+        self.tabular.record('x', x * 4)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.tabular.record('b', b * 5)
+        self.tabular.record('x', x * 5)
+        self.tabular.record('d', d * 5)
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        correct = [
+            {'a': str(a), 'b': str(b), 'c': str(c), 'x': None, 'd': None},
+            {'a': str(a * 2), 'b': '', 'c': str(c * 2), 'x': None, 'd': None},
+            {'a': '', 'b': '', 'c': '', 'x': str(x * 3), 'd': None},
+            {'a': '', 'b': str(b * 4), 'c': '', 'x': str(x * 4), 'd': None},
+            {'a': '', 'b': str(b*5), 'c': '', 'x': str(x*5), 'd': str(d*5)},
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    def test_record_fixed_header_length_long(self):
+        self.csv_output._inconsistency_handling = 'fixed_header_length'
+
+        foo = 1
+        bar = 10
+        bar_long = 'bar' * self.csv_output._header_length
+        # 'foo,' takes 4 characters
+        bar_long_truncated = bar_long[:self.csv_output._header_length - 4]
+        self.tabular.record('foo', foo)
+        self.tabular.record(bar_long, bar)
+        self.csv_output.record(self.tabular)
+        self.tabular.record('foo', foo * 2)
+        self.tabular.record(bar_long, None)
+
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        correct = [
+            {'foo': str(foo), bar_long_truncated: str(bar)},
+            {'foo': str(foo * 2), bar_long_truncated: ''},
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
@@ -89,6 +257,9 @@ class TestCsvOutput:
         """Check the first row of a csv file and compare it to known values."""
         with open(self.log_file.name, 'r') as file:
             reader = csv.DictReader(file)
+            if self.csv_output._inconsistency_handling == \
+                    'fixed_header_length':
+                reader.fieldnames[-1] = reader.fieldnames[-1].rstrip()
 
             for correct_row in correct:
                 row = next(reader)


### PR DESCRIPTION
See rlworkgroup#45

This commit adds robust handling of inconsistent TabularInput keys,
with two implementations. The current behavior of ignoring new keys is
kept as the default, but the users can now optionally specify how to
record new keys and the corresponding values. (They must consider the
trade-off between the two implementations.)

I tried to follow closely to the [contribution guide](https://github.com/rlworkgroup/dowel/blob/master/CONTRIBUTING.md), but there seems to be some differences between the Google style and what is in the codebase (e.g. "Args:" vs ":param"). Hopefully I made the right choices.

I couldn't quite think of a perfect solution because of limitation in file IO (i.e. remove or replacing content in a file stream), but I hope what I have here is sufficient.